### PR TITLE
Improve compatibility with turtle-1.3.1

### DIFF
--- a/src/DotLinker.hs
+++ b/src/DotLinker.hs
@@ -17,7 +17,7 @@ import Data.Text.Encoding (decodeUtf8)
 import Filesystem.Path.CurrentOS (FilePath, encode)
 import System.Posix.Files (createSymbolicLink)
 import Prelude hiding (takeWhile, FilePath)
-import Turtle ((</>), (<>), MonadIO, fromText, toText, liftIO)
+import Turtle ((</>), (<>), (%), MonadIO, fromText, toText, liftIO)
 import qualified Turtle as T
 
 import DotLinker.Parsers
@@ -45,12 +45,13 @@ matchAndLink (v, dryRun) mapped dotfile = do
         else do
           realdotfile <- T.realpath dotfile
           ensurePathExist target
-          T.echo $ "Linking " <> asText realdotfile <> " -> " <> asText target
+          echoT $ "Linking " <> asText realdotfile <> " -> " <> asText target
           unless dryRun $ lns realdotfile target
       where
         ensurePathExist = T.mktree . T.directory
 
-    vEcho = when v . T.echo
+    vEcho = when v . echoT
+    echoT = T.printf (T.s % "\n")
 
 -- | Expand any enviroment variables found in the path
 expandPath :: MonadIO io => FilePath -> io FilePath


### PR DESCRIPTION
This commit should prevent some breakage related to `turtle-1.3.1`, assuming you merge this commit and upload a new version of this package to Hackage (you'll also probably want to do a minor version bump).